### PR TITLE
Add the ability to provide an initial checkpoint for a stream to replicate

### DIFF
--- a/Ditto.sln
+++ b/Ditto.sln
@@ -1,11 +1,10 @@
-
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 15
 VisualStudioVersion = 15.0.26124.0
 MinimumVisualStudioVersion = 15.0.26124.0
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{B7DCD82B-26FF-41B4-9AC9-82397D66FCC0}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Ditto", "src\Ditto\Ditto.csproj", "{D0DAEDE8-64BC-48BB-9EAE-1D56F3765338}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Ditto", "src\Ditto\Ditto.csproj", "{D0DAEDE8-64BC-48BB-9EAE-1D56F3765338}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -16,24 +15,27 @@ Global
 		Release|x64 = Release|x64
 		Release|x86 = Release|x86
 	EndGlobalSection
-	GlobalSection(SolutionProperties) = preSolution
-		HideSolutionNode = FALSE
-	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{D0DAEDE8-64BC-48BB-9EAE-1D56F3765338}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{D0DAEDE8-64BC-48BB-9EAE-1D56F3765338}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{D0DAEDE8-64BC-48BB-9EAE-1D56F3765338}.Debug|x64.ActiveCfg = Debug|x64
-		{D0DAEDE8-64BC-48BB-9EAE-1D56F3765338}.Debug|x64.Build.0 = Debug|x64
-		{D0DAEDE8-64BC-48BB-9EAE-1D56F3765338}.Debug|x86.ActiveCfg = Debug|x86
-		{D0DAEDE8-64BC-48BB-9EAE-1D56F3765338}.Debug|x86.Build.0 = Debug|x86
+		{D0DAEDE8-64BC-48BB-9EAE-1D56F3765338}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{D0DAEDE8-64BC-48BB-9EAE-1D56F3765338}.Debug|x64.Build.0 = Debug|Any CPU
+		{D0DAEDE8-64BC-48BB-9EAE-1D56F3765338}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{D0DAEDE8-64BC-48BB-9EAE-1D56F3765338}.Debug|x86.Build.0 = Debug|Any CPU
 		{D0DAEDE8-64BC-48BB-9EAE-1D56F3765338}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{D0DAEDE8-64BC-48BB-9EAE-1D56F3765338}.Release|Any CPU.Build.0 = Release|Any CPU
-		{D0DAEDE8-64BC-48BB-9EAE-1D56F3765338}.Release|x64.ActiveCfg = Release|x64
-		{D0DAEDE8-64BC-48BB-9EAE-1D56F3765338}.Release|x64.Build.0 = Release|x64
-		{D0DAEDE8-64BC-48BB-9EAE-1D56F3765338}.Release|x86.ActiveCfg = Release|x86
-		{D0DAEDE8-64BC-48BB-9EAE-1D56F3765338}.Release|x86.Build.0 = Release|x86
+		{D0DAEDE8-64BC-48BB-9EAE-1D56F3765338}.Release|x64.ActiveCfg = Release|Any CPU
+		{D0DAEDE8-64BC-48BB-9EAE-1D56F3765338}.Release|x64.Build.0 = Release|Any CPU
+		{D0DAEDE8-64BC-48BB-9EAE-1D56F3765338}.Release|x86.ActiveCfg = Release|Any CPU
+		{D0DAEDE8-64BC-48BB-9EAE-1D56F3765338}.Release|x86.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
 	EndGlobalSection
 	GlobalSection(NestedProjects) = preSolution
 		{D0DAEDE8-64BC-48BB-9EAE-1D56F3765338} = {B7DCD82B-26FF-41B4-9AC9-82397D66FCC0}
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {917F1932-0751-4880-A760-99A682D24FEC}
 	EndGlobalSection
 EndGlobal

--- a/README.md
+++ b/README.md
@@ -15,17 +15,19 @@ The application can be configured via JSON (`appsettings.json`) or using Environ
 | SourceEventStoreConnectionString | Ditto_Settings:SourceEventStoreConnectionString |   | The source event store connection string |
 | DestinationEventStoreConnectionString | Ditto_Settings:DestinationEventStoreConnectionString |   | The destination event store connection string |
 | CheckpointSavingInterval | Ditto_Settings:CheckpointSavingInterval | 5000 | The interval in milliseconds before the current checkpoint is saved |
-| StreamIdentifiers | Ditto_Settings:StreamIdentifiers |  | Semi-colon (`;`) separated identifiers of streams that should be replicated* |
 | CheckpointManagerRetryCount | Ditto_Settings:CheckpointManagerRetryCount | 5 | The number of times the Checkpoint Manager should attempt to save the Checkpoint in the event of a failure
 | CheckpointManagerRetryInterval | Ditto_Settings:CheckpointManagerRetryInterval | 1000 | The interval in milliseconds between Checkpoint Manager retries |
 | ReplicationThrottleInterval | Ditto_Settings:ReplicationThrottleInterval | 0 | The interval in milliseconds to wait between events. This can be useful if you want to reduce the load on your source server |
+| StreamIdentifiers | Ditto_Settings:StreamIdentifiers |  | **Obsolete:** *This is left for backwards compatibility. Consider using StreamsToReplicate below.* Semi-colon (`;`) separated identifiers of streams that should be replicated* |
+| StreamsToReplicate | Ditto_StreamsToReplicate:Settings |  | A collection of *ReplicationSettings* which contains the identifier of a stream that should be replicated* and the optional *InitialCheckpoint* property which dictates the starting checkpoint to be used when one does not already exist. Please note that this will not perform version checking when appending to the destination stream | 
 
 
-**Note - When replicating category streams you will need to escape the `$` in the stream identifier under docker, for example, to replicate the category stream `$ce-emails` set your stream identifier to `$$ce-emails`.
+*Note - When replicating category streams you will need to escape the `$` in the stream identifier under docker, for example, to replicate the category stream `$ce-emails` set your stream identifier to `$$ce-emails`.
+
 
 ### Ditto Checkpoints
 
-Ditto will start a new catchup subscription for each stream you subscribe to and automatically take care of maintaining the last checkpoint of each stream. This means you can safely stop and start Ditto and it will pick up where it left off. 
+Ditto will start a new catchup subscription for each stream you subscribe to and automatically take care of maintaining the last checkpoint of each stream. This means you can safely stop and start Ditto and it will pick up where it left off.
 
 Ditto generates a checkpoint stream for each stream you subscribe to, named according to the source stream. For example, when subscribing to the `$ce-emails` stream, a new checkpoint stream will be created on the destination server called `Ditto_ReplicatingConsumer_ce_emails_Checkpoint`. Each time the Ditto Checkpoint Manager saves the current checkpoint, a `Checkpoint` event is written to the above stream, for example:
 
@@ -36,6 +38,8 @@ Ditto generates a checkpoint stream for each stream you subscribe to, named acco
 ```
 
 The Ditto Checkpoint Manager defers the writing of checkpoints according to the `CheckpointSavingInterval` setting. If you're replicating a large number of events it does not make sense to write the checkpoint after each event is replicated. We usually set this to around 10 seconds.
+
+If you need to start replicating a new stream from a specific checkpoint onward then you can optionally specify the *InitialCheckpoint* property which dictates the starting checkpoint to be used when one does not already exist.
 
 #### Idempotency
 

--- a/src/Ditto/ConsumerManager.cs
+++ b/src/Ditto/ConsumerManager.cs
@@ -84,6 +84,21 @@ namespace Ditto
         {           
             var consumerId = GetConsumerId(runningConsumer.Consumer);
             long? checkpoint = await _checkpointManager.LoadCheckpointAsync(consumerId);
+
+            if (!checkpoint.HasValue)
+            {
+                if (runningConsumer.Consumer.InitialCheckpoint.HasValue)
+                {
+                    _logger.Information("Consumer {Consumer} subscribed to {StreamName} has no checkpoint set. Starting from initial checkpoint #{Checkpoint}", 
+                        runningConsumer.Consumer.GetType().Name, runningConsumer.Consumer.StreamName, runningConsumer.Consumer.InitialCheckpoint);
+                    checkpoint = runningConsumer.Consumer.InitialCheckpoint;
+                }
+                else
+                {
+                    _logger.Information("Consumer {Consumer} subscribed to {StreamName} has no checkpoint set. Starting from beginning of stream's source.",
+                        runningConsumer.Consumer.GetType().Name, runningConsumer.Consumer.StreamName);
+                }
+            }
             
             _logger.Information("Starting {Consumer} subscribed to {StreamName} from Checkpoint #{Checkpoint}",
                 runningConsumer.Consumer.GetType().Name, runningConsumer.Consumer.StreamName, checkpoint);

--- a/src/Ditto/Ditto.csproj
+++ b/src/Ditto/Ditto.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<?xml version="1.0" encoding="utf-8" standalone="yes"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
@@ -6,20 +6,20 @@
     <LangVersion>Latest</LangVersion>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Configuration" Version="2.0.0"/>
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="2.0.0"/>
-    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="2.0.0"/>
-    <PackageReference Include="Serilog" Version="2.6.0"/>
-    <PackageReference Include="Serilog.Sinks.Seq" Version="3.4.0"/>
-    <PackageReference Include="Serilog.Sinks.ColoredConsole" Version="3.0.1"/>
-    <PackageReference Include="Serilog.Enrichers.Environment" Version="2.1.2"/>
-    <PackageReference Include="Serilog.Settings.Configuration" Version="2.4.0"/>
-    <PackageReference Include="structuremap" Version="4.5.2"/>
-    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="2.0.0"/>
-    <PackageReference Include="SerilogTimings" Version="2.2.0"/>
-    <PackageReference Include="EventStore.ClientAPI.NetCore" Version="4.0.3-rc"/>
-    <PackageReference Include="Newtonsoft.Json" Version="10.0.3"/>
-    <PackageReference Include="Polly" Version="5.6.1"/>
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="2.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="2.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="2.0.0" />
+    <PackageReference Include="Serilog" Version="2.6.0" />
+    <PackageReference Include="Serilog.Sinks.Seq" Version="3.4.0" />
+    <PackageReference Include="Serilog.Sinks.ColoredConsole" Version="3.0.1" />
+    <PackageReference Include="Serilog.Enrichers.Environment" Version="2.1.2" />
+    <PackageReference Include="Serilog.Settings.Configuration" Version="2.4.0" />
+    <PackageReference Include="structuremap" Version="4.5.2" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="2.0.0" />
+    <PackageReference Include="SerilogTimings" Version="2.2.0" />
+    <PackageReference Include="EventStore.ClientAPI.NetCore" Version="4.0.3-rc" />
+    <PackageReference Include="Newtonsoft.Json" Version="10.0.3" />
+    <PackageReference Include="Polly" Version="5.6.1" />
   </ItemGroup>
   <ItemGroup>
     <None Update="appsettings.*">

--- a/src/Ditto/Ditto.csproj
+++ b/src/Ditto/Ditto.csproj
@@ -10,6 +10,7 @@
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="2.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="2.0.0" />
     <PackageReference Include="Serilog" Version="2.6.0" />
+    <PackageReference Include="Serilog.Sinks.Elasticsearch" Version="6.5.0" />
     <PackageReference Include="Serilog.Sinks.Seq" Version="3.4.0" />
     <PackageReference Include="Serilog.Sinks.ColoredConsole" Version="3.0.1" />
     <PackageReference Include="Serilog.Enrichers.Environment" Version="2.1.2" />

--- a/src/Ditto/EventStoreCheckpointManager.cs
+++ b/src/Ditto/EventStoreCheckpointManager.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
+using Ditto.Settings;
 using EventStore.ClientAPI;
 using Newtonsoft.Json;
 using Polly;

--- a/src/Ditto/IConsumer.cs
+++ b/src/Ditto/IConsumer.cs
@@ -11,7 +11,12 @@ namespace Ditto
         /// Gets the name of the stream to consumer
         /// </summary>
         string StreamName { get; }
-        
+
+        /// <summary>
+        /// Gets the initial checkpoint to be used if none has been set previously.
+        /// </summary>
+        long? InitialCheckpoint { get; }
+
         /// <summary>
         /// Indicates whether an event with the specified type name can be consumed
         /// </summary>

--- a/src/Ditto/Settings/AppSettings.cs
+++ b/src/Ditto/Settings/AppSettings.cs
@@ -1,0 +1,59 @@
+using System;
+using System.Collections.Generic;
+
+namespace Ditto.Settings
+{
+    /// <summary>
+    /// The application settings
+    /// </summary>
+    public class AppSettings
+    {
+        /// <summary>
+        /// Gets or sets the connection string to the source Event Store
+        /// </summary>
+        public string SourceEventStoreConnectionString { get; set; }
+
+        /// <summary>
+        /// Gets or sets the connection string to the destination Event Store
+        /// </summary>
+        public string DestinationEventStoreConnectionString { get; set; }
+
+        /// <summary>
+        /// Gets or sets the IDs of the streams that should be copied. Separated with a semi colon ";"
+        /// </summary>
+        /// <remarks>This property is now obsolete and is left for backwards compatibility. Use <see cref="StreamsToReplicateSettings"/> instead.</remarks>
+        [Obsolete("Use StreamsToReplicateSettings instead.")]
+        public string StreamIdentifiers { get; set; }
+
+        /// <summary>
+        /// Gets or sets the checkpoint manager retry count 
+        /// </summary>
+        public int CheckpointManagerRetryCount { get; set; }
+
+        /// <summary>
+        /// Gets or sets the checkpoint manager retry interval in milliseconds
+        /// </summary>
+        public int CheckpointManagerRetryInterval { get; set; }
+
+        /// <summary>
+        /// Gets or sets the interval in milliseconds that consumer checkpoints are saved
+        /// </summary>
+        public int CheckpointSavingInterval { get; set; }
+
+        /// <summary>
+        /// Gets or sets the time in milliseconds to wait between event handling
+        /// </summary>
+        public int? ReplicationThrottleInterval { get; set; }
+
+        /// <summary>
+        /// A collection of stream identifiiers to be replicated.
+        /// </summary>
+        /// <returns>List of stream identifiers.</returns>
+        /// <remarks>This property is now obsolete and is left for backwards compatibility. Use <see cref="StreamsToReplicateSettings"/> instead.</remarks>
+        [Obsolete("Use StreamsToReplicateSettings instead.")]
+        public IEnumerable<string> GetStreamsToReplicate()
+        {
+            return (StreamIdentifiers ?? "").Trim().Split(';', StringSplitOptions.RemoveEmptyEntries);
+        }
+    }
+}

--- a/src/Ditto/Settings/ReplicationSettings.cs
+++ b/src/Ditto/Settings/ReplicationSettings.cs
@@ -1,0 +1,27 @@
+﻿namespace Ditto.Settings
+{
+    /// <summary>
+    /// Settings related to a stream to be replicated.
+    /// </summary>
+    public class ReplicationSettings
+    {
+        /// <summary>
+        /// Gets or sets the ID of the stream that should be copied
+        /// </summary>
+        public string StreamIdentifier { get; set; }
+
+        /// <summary>
+        /// Gets or sets the initial checkpoint this stream should start replicating from
+        /// if this is the start of the replication process and no checkpoint exists.
+        /// </summary>
+        public long? InitialCheckpoint { get; set; }
+
+        /// <summary>
+        /// A flag to denote if a version check should be perform when appending to the replicated
+        /// stream. This is true when no initial checkpoint has been specified since the whole stream
+        /// is expected to be replicated but otherwise false since it would be impossible to guarantee
+        /// version parity between source and destination.
+        /// </summary>
+        public bool PerformVersionCheck => !InitialCheckpoint.HasValue;
+    }
+}

--- a/src/Ditto/Settings/StreamsToReplicateSettings.cs
+++ b/src/Ditto/Settings/StreamsToReplicateSettings.cs
@@ -1,0 +1,15 @@
+﻿using System.Collections.Generic;
+
+namespace Ditto.Settings
+{
+    /// <summary>
+    /// A collection of settings related to a stream to be replicated.
+    /// </summary>
+    public class StreamsToReplicateSettings
+    {
+        /// <summary>
+        /// A collection of settings related to a stream to be replicated.
+        /// </summary>
+        public List<ReplicationSettings> Settings { get; set; }
+    }
+}

--- a/src/Ditto/appsettings.json
+++ b/src/Ditto/appsettings.json
@@ -4,8 +4,15 @@
     "DestinationEventStoreConnectionString": "ConnectTo=tcp://admin:changeit@localhost:3113;",
     "CheckpointManagerRetryCount": 5,
     "CheckpointManagerRetryInterval": 1000,
-    "CheckpointSavingInterval": 5000,
-    "StreamIdentifiers": "$ce-emails"
+    "CheckpointSavingInterval": 5000
+  },
+  "StreamsToReplicate": {
+    "Settings": [
+      {
+        "StreamIdentifier": "$ce-emails",
+        "InitialCheckpoint": 1
+      }
+    ]
   },
   "Serilog": {
     "Using": [

--- a/src/Ditto/appsettings.json
+++ b/src/Ditto/appsettings.json
@@ -9,8 +9,7 @@
   "StreamsToReplicate": {
     "Settings": [
       {
-        "StreamIdentifier": "$ce-emails",
-        "InitialCheckpoint": 1
+        "StreamIdentifier": "$ce-emails"
       }
     ]
   },


### PR DESCRIPTION
* Changed `appsettings` so that a list of streams to be replicated can be specified along with an initial checkpoint number which will be used in case one has not been set already.
* Backwards compatibility in `appsettings` is maintained by converting the existing semi-colon separated string into the above object array.
* When replicating a stream which has an initial checkpoint provided then the event number check is skipped since it can no longer work with events being skipped.