### PR TITLE
Readonly mode

### DIFF
--- a/src/Ditto/AppService.cs
+++ b/src/Ditto/AppService.cs
@@ -20,7 +20,7 @@ namespace Ditto
         /// <param name="consumerManager"></param>
         public AppService(ILogger logger, IConsumerManager consumerManager)
         {
-            _logger = logger ?? throw new System.ArgumentNullException(nameof(logger));
+            _logger = logger?.ForContext<AppService>() ?? throw new System.ArgumentNullException(nameof(logger));
             _consumerManager = consumerManager ?? throw new System.ArgumentNullException(nameof(consumerManager));
         }
 

--- a/src/Ditto/AppSettings.cs
+++ b/src/Ditto/AppSettings.cs
@@ -43,6 +43,11 @@ namespace Ditto
         /// </summary>
         public TimeSpan? TimeToLive { get; set; }
 
+        /// <summary>
+        /// Gets or sets whether to only read from the target cluster and skip replication for testing purposes
+        /// </summary>
+        public bool ReadOnly { get; set; }
+
         public class Subscription
         {
             public string StreamName { get; set; }

--- a/src/Ditto/Program.cs
+++ b/src/Ditto/Program.cs
@@ -71,6 +71,7 @@ namespace Ditto
 
                 if (metrics.Enabled)
                 {
+                    _logger.Information("Starting metrics server at {MetricsUrl}:{MetricsPort", metrics.Path, metrics.Port);
                     _metricsServer = new MetricServer(port: metrics.Port, url: metrics.Path);
                     _metricsServer.Start();
                 }

--- a/src/Ditto/ReplicatingConsumer.cs
+++ b/src/Ditto/ReplicatingConsumer.cs
@@ -12,10 +12,12 @@ namespace Ditto
     /// Stream consumer that replicates to the destination event store
     /// </summary>
     public class ReplicatingConsumer : ICompetingConsumer
-    {
+    {        
         private readonly IEventStoreConnection _connection;
         private readonly Serilog.ILogger _logger;
         private readonly AppSettings _settings;
+        private readonly StreamMetadata _streamMetadata;
+        private readonly bool _ttl;
 
         public ReplicatingConsumer(
             IEventStoreConnection connection, Serilog.ILogger logger, AppSettings settings, string streamName, string groupName)
@@ -25,6 +27,12 @@ namespace Ditto
             _settings = settings ?? throw new ArgumentNullException(nameof(settings));
             StreamName = streamName ?? throw new ArgumentNullException(nameof(streamName));
             GroupName = groupName ?? throw new ArgumentNullException(nameof(groupName));
+
+            if (_settings.TimeToLive.GetValueOrDefault().TotalMilliseconds > 0)
+            {
+                _streamMetadata = StreamMetadata.Build().SetMaxAge(_settings.TimeToLive.Value);
+                _ttl = true;
+            }
         }
 
         public string StreamName { get; }
@@ -59,7 +67,7 @@ namespace Ditto
                 );
             }
 
-            if (_settings.TimeToLive.GetValueOrDefault().TotalMilliseconds > 0 && result.NextExpectedVersion == 0) // New stream created
+            if (_ttl && result.NextExpectedVersion == 0) // New stream created
                 await SetStreamMetadataAsync(resolvedEvent.Event.EventStreamId);
 
             if (_settings.ReplicationThrottleInterval.GetValueOrDefault() > 0)
@@ -71,10 +79,7 @@ namespace Ditto
             using (_logger.OperationAt(LogEventLevel.Debug).Time("Setting TTL on stream {StreamName}", stream))
             using (DittoMetrics.IODuration.WithIOLabels("eventstore", "ditto-destination", "set_stream_metadata").NewTimer())
             {
-                StreamMetadata streamMetadata = StreamMetadata.Build()
-                    .SetMaxAge(_settings.TimeToLive.Value);
-                
-                await _connection.SetStreamMetadataAsync(stream, ExpectedVersion.Any, streamMetadata);
+                await _connection.SetStreamMetadataAsync(stream, ExpectedVersion.Any, _streamMetadata);
             }
         }
     }

--- a/src/Ditto/ReplicatingConsumer.cs
+++ b/src/Ditto/ReplicatingConsumer.cs
@@ -12,7 +12,7 @@ namespace Ditto
     /// Stream consumer that replicates to the destination event store
     /// </summary>
     public class ReplicatingConsumer : ICompetingConsumer
-    {        
+    {
         private readonly IEventStoreConnection _connection;
         private readonly Serilog.ILogger _logger;
         private readonly AppSettings _settings;
@@ -42,6 +42,18 @@ namespace Ditto
         public async Task ConsumeAsync(string eventType, ResolvedEvent resolvedEvent)
         {
             if (string.IsNullOrWhiteSpace(eventType)) throw new ArgumentException("Event type required", nameof(eventType));
+
+            if (_settings.ReadOnly)
+            {
+                _logger.Debug("Received {EventType} #{EventNumber} from {StreamName} (Original Event: #{OriginalEventNumber})",
+                    resolvedEvent.Event.EventType,
+                    resolvedEvent.Event.EventNumber,
+                    resolvedEvent.Event.EventStreamId,
+                    resolvedEvent.OriginalEventNumber
+                );
+
+                return;
+            }
 
             var eventData = new EventData(
                 resolvedEvent.Event.EventId,


### PR DESCRIPTION
Adds an option to run Ditto in read-only mode where it will receive events from the source cluster but not replicate them to the destination.